### PR TITLE
Manage user profile organizations

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -12,6 +12,7 @@ import { useTasks } from "@/hooks/use-tasks"
 import { useArchive } from "@/hooks/use-archive"
 import { useAuth } from "@/components/auth/auth-provider"
 import { useGitHubRepos, useGitHubBranches } from "@/hooks/use-github-repos"
+import { useUserOrgs } from "@/hooks/use-user-orgs"
 import { useLocalStorage } from "@/hooks/use-local-storage"
 import { useConfirmation } from "@/hooks/use-confirmation"
 import { ConfirmationDialog } from "@/components/ui/confirmation-dialog"
@@ -45,7 +46,8 @@ export default function Home() {
   const [selectedBranch, setSelectedBranch, branchLoaded] = useLocalStorage('selected_branch', 'main')
   
   // GitHub data
-  const { repos, loading: reposLoading } = useGitHubRepos(token)
+  const { orgs } = useUserOrgs()
+  const { repos, loading: reposLoading } = useGitHubRepos(token, orgs)
   const { branches, loading: branchesLoading } = useGitHubBranches(token, selectedRepo)
 
   // Default demo configuration

--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -1,0 +1,102 @@
+'use client'
+import { useState } from "react"
+import { useUserOrgs } from "@/hooks/use-user-orgs"
+import { useAuth } from "@/components/auth/auth-provider"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { X, PlusCircle, RefreshCw } from "lucide-react"
+import { componentTokens, commonTypographyCombinations, getBodyClasses, getGapSpacing, getMarginSpacing } from "@/lib/design-tokens"
+
+export default function ProfilePage() {
+  const { user } = useAuth()
+  const { orgs, addOrg, removeOrg } = useUserOrgs()
+
+  const [newOrg, setNewOrg] = useState("")
+  const [adding, setAdding] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Validate & add organisation
+  const handleAdd = async () => {
+    const org = newOrg.trim()
+    if (!org) return
+    setAdding(true)
+    setError(null)
+    try {
+      const resp = await fetch(`https://api.github.com/orgs/${org}`)
+      if (resp.ok) {
+        addOrg(org)
+        setNewOrg("")
+      } else if (resp.status === 404) {
+        setError("Organisation not found on GitHub")
+      } else {
+        setError("Failed to validate organisation")
+      }
+    } catch (e) {
+      console.error(e)
+      setError("Network error validating organisation")
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault()
+      handleAdd()
+    }
+  }
+
+  return (
+    <div className={componentTokens.ui.layout.page}>
+      <div className={componentTokens.ui.layout.container}>
+        <h1 className={`${commonTypographyCombinations.pageTitle} ${getMarginSpacing('lg')}`}>Profile</h1>
+
+        {user && (
+          <div className={`${getMarginSpacing('lg')}`}>Logged in as <span className="font-medium">{user.name || user.email}</span></div>
+        )}
+
+        <section className={componentTokens.ui.card.primary}>
+          <h2 className={`${commonTypographyCombinations.sectionHeader} ${getMarginSpacing('md')}`}>GitHub Organisations</h2>
+
+          <div className={`flex items-center ${getGapSpacing('sm')} ${getMarginSpacing('md')}`}>
+            <Input
+              placeholder="Add organisation by name"
+              value={newOrg}
+              onChange={(e) => setNewOrg(e.target.value)}
+              onKeyDown={handleKeyDown}
+              className="w-64"
+              disabled={adding}
+            />
+            <Button
+              variant="outline"
+              onClick={handleAdd}
+              disabled={adding}
+            >
+              {adding ? <RefreshCw className="w-4 h-4 animate-spin" /> : <PlusCircle className="w-4 h-4 mr-1" />} Add
+            </Button>
+          </div>
+          {error && <p className={`text-red-500 ${getMarginSpacing('sm')}`}>{error}</p>}
+
+          {orgs.length === 0 ? (
+            <p className={getBodyClasses('muted')}>No additional organisations added.</p>
+          ) : (
+            <ul className={`flex flex-wrap ${getGapSpacing('sm')}`}>
+              {orgs.map((org) => (
+                <li key={org} className="relative group">
+                  <span className={`inline-flex items-center rounded-full border border-gray-700 px-3 py-1 text-sm ${getBodyClasses('secondary')}`}>{org}</span>
+                  <button
+                    aria-label="Remove organisation"
+                    onClick={() => removeOrg(org)}
+                    className="absolute -top-2 -right-2 hidden group-hover:block bg-gray-800 rounded-full p-0.5 text-gray-300 hover:text-red-400"
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/frontend/app/tokens-demo/page.tsx
+++ b/frontend/app/tokens-demo/page.tsx
@@ -11,6 +11,7 @@ import Link from "next/link"
 import { useTasks } from "@/hooks/use-tasks"
 import { useAuth } from "@/components/auth/auth-provider"
 import { useGitHubRepos, useGitHubBranches } from "@/hooks/use-github-repos"
+import { useUserOrgs } from "@/hooks/use-user-orgs"
 import { useLocalStorage } from "@/hooks/use-local-storage"
 import { 
   getHeadingClasses, 
@@ -42,7 +43,8 @@ export default function TokensDemo() {
   const [selectedBranch, setSelectedBranch, branchLoaded] = useLocalStorage('selected_branch', 'main')
   
   // GitHub data
-  const { repos, loading: reposLoading } = useGitHubRepos(token)
+  const { orgs } = useUserOrgs()
+  const { repos, loading: reposLoading } = useGitHubRepos(token, orgs)
   const { branches, loading: branchesLoading } = useGitHubBranches(token, selectedRepo)
 
   // Default demo configuration

--- a/frontend/components/repository-select.tsx
+++ b/frontend/components/repository-select.tsx
@@ -7,6 +7,7 @@ import * as SelectPrimitive from "@radix-ui/react-select"
 import { useLocalStorage } from "@/hooks/use-local-storage"
 import { useAuth } from "@/components/auth/auth-provider"
 import { useGitHubRepos } from "@/hooks/use-github-repos"
+import { useUserOrgs } from "@/hooks/use-user-orgs"
 import { GitHubRepo } from "@/hooks/use-github-repos"
 import { cn } from "@/lib/utils"
 
@@ -40,11 +41,12 @@ export function RepositorySelect({
   demoRepoUrl = "https://github.com/aideator/helloworld",
   triggerClassName,
 }: RepositorySelectProps) {
-  // Auth state
+  // Auth and user orgs state
   const { token } = useAuth()
+  const { orgs } = useUserOrgs()
 
   // Fetch repos (up to 300) – see updated hook
-  const { repos, loading, error } = useGitHubRepos(token)
+  const { repos, loading, error } = useGitHubRepos(token, orgs)
 
   // Search term state with debouncing
   const [search, setSearch] = useState("")

--- a/frontend/hooks/use-user-orgs.ts
+++ b/frontend/hooks/use-user-orgs.ts
@@ -1,0 +1,25 @@
+import { useLocalStorage } from "@/hooks/use-local-storage"
+
+/**
+ * Hook for managing additional GitHub organisations that the user manually adds.
+ * Organisations are persisted to localStorage so they are available across sessions.
+ */
+export function useUserOrgs() {
+  // Persist list under a stable key
+  const [orgs, setOrgs] = useLocalStorage<string[]>("user_orgs", [])
+
+  const addOrg = (org: string) => {
+    const normalised = org.trim()
+    if (!normalised) return
+    setOrgs((prev) => {
+      if (prev.includes(normalised)) return prev
+      return [...prev, normalised]
+    })
+  }
+
+  const removeOrg = (org: string) => {
+    setOrgs((prev) => prev.filter((o) => o !== org))
+  }
+
+  return { orgs, addOrg, removeOrg }
+}


### PR DESCRIPTION
Add a profile page to allow users to manually add GitHub organizations, ensuring their repositories are discoverable even when OAuth token permissions are limited.

This addresses the limitation where a user's GitHub OAuth token might not have permissions to list all organizations they are a member of, preventing Aideator from discovering repositories within those organizations.